### PR TITLE
Renaming wuolah files correctly

### DIFF
--- a/gulagcleaner/gulagcleaner_extract.py
+++ b/gulagcleaner/gulagcleaner_extract.py
@@ -85,7 +85,7 @@ def deembed(pdf_path, replace=False):
         writer.addpages(pages)
         writer.write()
 
-        os.rename(output, output.replace('free-', ''))
+        os.rename(output, output.replace('wuolah-free-', ''))
         os.remove(intermediate_pdf_path)
 
         return {


### PR DESCRIPTION
He visto que hace tiempo cambiasteis el renombrado del prefijo que wuolah le mete a los archivos, supuestamente porque lo cambiaron de "wuolah-free-" a "free-" sin embargo esto ya no es así y ha vuelto como antes.