### PR TITLE
Fixes for new wuolah files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Gulag Cleaner
 
-Gulag Cleaner is a tool designed to remove advertisements from PDFs, making it easier to read and navigate documents without being disrupted by unwanted ads. It operates as a functional inverse of functions that insert PDF pages into other documents as Form XObjects, and is particularly useful for reversing the effects of the embedPages() function from the pdf-lib.js library.
+Gulag Cleaner is a tool designed to remove advertisements from PDFs, making it easier to read and navigate documents without being disrupted by unwanted ads.
+
+This tool does not just crop the ads out of the PDF, instead, we extract the original file without ads by manipulating the internal structure of the PDF, ensuring maximum quality.
 
 In addition to removing advertisements, Gulag Cleaner is also capable of extracting metadata, such as the author, subject, university, and more, from the file.
 
@@ -20,7 +22,7 @@ Gulag Cleaner can be used through both a Command Line Interface (CLI) and in you
 To use Gulag Cleaner through the CLI, simply run the following command, replacing `<filename>` with the name of your PDF file:
 
 ```
-gulagcleaner <filename> [-r] [-h] [-v]
+gulagcleaner <filename> [-r] [-h] [-o] [-v]
 ```
 
 ### Code
@@ -38,6 +40,7 @@ return_msg = deembed("file.pdf")
 Gulag Cleaner provides several options for it's usage:
 
 > * '-r': Replaces the original file with the cleaned version.
+> * '-o': Uses the old deembeding method (for files older than 18/05/2023).
 > * '-h': Displays the help message, providing information on how to use Gulag Cleaner.
 > * '-v': Displays the current version of Gulag Cleaner.
 

--- a/gulagcleaner/command_line.py
+++ b/gulagcleaner/command_line.py
@@ -10,34 +10,37 @@ def main():
     Available CLI arguments:
     -h : displays help information
     -r : replaces the original file with the deembedded file
+    -o : uses the old deembeding method (for files older than 18/05/2023)
     -v : displays the version of the program
+
     '''
     import sys
     import os.path
 
     # Check for the -h argument
     if '-h' in sys.argv:
-        print("Usage: gulagcleaner [-h] [-r] [-v] <filename>")
+        print("Usage: gulagcleaner [-h] [-r] [-o] [-v] <filename>")
         print("")
-        print("Deembeds pages from a PDF file")
+        print("Deembeds pages from a PDF file.")
         print("")
         print("Positional arguments:")
-        print("  filename      the PDF file to deembed pages from")
+        print("  filename      the PDF file to deembed pages from.")
         print("")
         print("Optional arguments:")
-        print("  -h            show this help message and exit")
-        print("  -r            replaces the original file with the deembedded file")
-        print("  -v            shows the version of the program")
+        print("  -h            show this help message and exit.")
+        print("  -r            replaces the original file with the deembedded file.")
+        print("  -o            uses the old deembeding method (for files older than 18/05/2023).")
+        print("  -v            shows the version of the program.")
         return
 
     # Check for the -v argument
     if '-v' in sys.argv:
-        print("actual version: 0.4.8")
+        print("actual version: 0.5.0")
         return
 
     # Get the filename argument
     if len(sys.argv) < 2:
-        print('Usage: gulagcleaner [-h] [-r] [-v] <filename>')
+        print('Usage: gulagcleaner [-h] [-r] [-o] [-v] <filename>')
         return
     filename = sys.argv[-1]
 
@@ -49,8 +52,14 @@ def main():
     # Check if the -r argument is present
     replace = '-r' in sys.argv
 
+     # Check if the -o argument is present
+    if '-o' in sys.argv:
+        method = "old"
+    else:
+        method = "new"
+    
     # Call the deembed function
-    return_msg = gulagcleaner_extract.deembed(filename, replace)
+    return_msg = gulagcleaner_extract.deembed(filename, replace,method)
     if return_msg["Success"]:
         print("Deembedding successful. File saved in", return_msg["return_path"])
         print("Metadata:")

--- a/gulagcleaner/command_line.py
+++ b/gulagcleaner/command_line.py
@@ -35,7 +35,7 @@ def main():
 
     # Check for the -v argument
     if '-v' in sys.argv:
-        print("actual version: 0.5.0")
+        print("actual version: 0.5.1")
         return
 
     # Get the filename argument

--- a/gulagcleaner/gulagcleaner_extract.py
+++ b/gulagcleaner/gulagcleaner_extract.py
@@ -94,7 +94,7 @@ def deembed(pdf_path, replace=False, method="new"):
 
         if method=="old":
             xobjs = list(find_objects(pdf.pages, valid_subtypes=(PdfName.Form, PdfName.Dummy)))
-            pages = [wrap_object(item, 1000, 0.5 * 72) for item in xobjs]
+            newpages = [wrap_object(item, 1000, 0.5 * 72) for item in xobjs]
 
             if not xobjs:
                 os.remove(intermediate_pdf_path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [metadata]
 name = gulagcleaner
-version = 0.4.8
+version = 0.5.0
 author = YM162,KosmicKatXV,pgalinanes
-author_email = david.fontaneda@estudiante.uam.es
-description = Herramienta de eliminación de anuncios para PDFs generados por la plataforma Wuolah.
+author_email = david.fontaneda16@gmail.com
+description = Ad removal tool for PDFs written in python.
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/YM162/gulag-cleaner-cli

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gulagcleaner
-version = 0.5.0
+version = 0.5.1
 author = YM162,KosmicKatXV,pgalinanes
 author_email = david.fontaneda16@gmail.com
 description = Ad removal tool for PDFs written in python.


### PR DESCRIPTION
All PDFs downloaded after 18/05/23 have a different internal structure, making the old method of extracting pages obsolete.

This pr introduces a new method for extracting the original page via /Contents dictionary manipulation. The old method can still be used with the '-o' flag.